### PR TITLE
Add Rust Diesel Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# convenience-images
+# Convenience Images
 A place for publishing dockerfiles that come in handy sometimes.
+
+These images can be used to speed up github actions in the event that specific dependencies need to be installed. For example, `rust-diesel-pg` is built on top of the rust image, but includes an installation of the `diesel-client` with postgres features. It can be used to run database migrations.
+
+## Deployment
+
+We use `rust-diesel-pg` as an example:
+
+```sh
+export DOCKER_USER=bh2smith
+export IMAGE=rust-diesel-pg
+cd $IMAGE
+docker docker build -t ${DOCKER_USER}/${IMAGE} .
+docker push ${DOCKER_USER}/${IMAGE}
+```
+

--- a/rust-diesel-pg/Dockerfile
+++ b/rust-diesel-pg/Dockerfile
@@ -1,0 +1,6 @@
+FROM rust:latest
+
+RUN apt-get update && apt-get install -y libpq-dev
+
+# Install diesel_cli
+RUN cargo install --debug diesel_cli --no-default-features --features postgres


### PR DESCRIPTION
This image has been built and [published to dockerhub](https://hub.docker.com/repository/docker/bh2smith/rust-diesel-pg/).


Includes a rust:latest base layer with an installation of [diesel-cli](https://diesel.rs/guides/getting-started) (postgres only).

Saves ~30 seconds on github actions (cf [before](https://github.com/Mintbase/evm-indexer/actions/runs/6849323900/job/18621275255) and [after](https://github.com/Mintbase/evm-indexer/actions/runs/6849751593/job/18622566034)).