### PR TITLE
Add Near Rust Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # Convenience Images
 A place for publishing dockerfiles that come in handy sometimes.
 
-These images can be used to speed up github actions in the event that specific dependencies need to be installed. For example, `rust-diesel-pg` is built on top of the rust image, but includes an installation of the `diesel-client` with postgres features. It can be used to run database migrations.
+These images can be used to speed up github actions in the event that specific dependencies need to be installed.
+
+## Rust Diesel
+
+Built on top of the rust image, but includes an installation of the `diesel-client` with postgres features. It can be used to run database migrations.
+
+Dockerhub: https://hub.docker.com/repository/docker/bh2smith/rust-diesel-pg
+
+## Near Rust
+
+Includes rust:latest⁠ as base layer along with [wasm32-unknown-unknown](https://github.com/rustwasm/wasm-bindgen) target and [cargo-make](https://github.com/sagiegurari/cargo-make).
+
+Primarily intended for [Near Smart Contract Development](https://github.com/near/near-sdk-rs)
+
+Dockerhub: https://hub.docker.com/repository/docker/bh2smith/near-rust/
 
 ## Deployment
 
-We use `rust-diesel-pg` as an example:
 
 ```sh
-export DOCKER_USER=bh2smith
-export IMAGE=rust-diesel-pg
-cd $IMAGE
-docker docker build -t ${DOCKER_USER}/${IMAGE} .
-docker push ${DOCKER_USER}/${IMAGE}
+./publish DIRECTORY_NAME
 ```
-

--- a/near-rust/Dockerfile
+++ b/near-rust/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:latest
+
+# Install rust wasm target
+RUN rustup target add wasm32-unknown-unknown
+# Install cargo-make
+RUN cargo install cargo-make
+# Install near-cli-rs
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.10.2/near-cli-rs-installer.sh | sh

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if the argument is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <image-name>"
+  exit 1
+fi
+
+# Set environment variables
+export DOCKER_USER=bh2smith
+export IMAGE=$1
+
+# Change to the directory specified by the image name
+cd $IMAGE || exit
+
+# Build and push the Docker image
+docker build -t ${DOCKER_USER}/${IMAGE} .
+docker push ${DOCKER_USER}/${IMAGE}


### PR DESCRIPTION
Adding image for near contract development (CI). Includes
- wasm target
- cargo-make
- nearl-cli-rs